### PR TITLE
Normalize imports to package style

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,4 +2,4 @@ FROM python:3.10-slim
 WORKDIR /app
 COPY . .
 RUN pip install -r requirements.txt
-CMD ["uvicorn", "src.api.app:app", "--host", "0.0.0.0"]
+CMD ["uvicorn", "api.app:app", "--host", "0.0.0.0"]

--- a/examples/example_query.py
+++ b/examples/example_query.py
@@ -1,4 +1,4 @@
-from src.rag_core import ContextualHybridRAG
+from rag_core import ContextualHybridRAG
 
 rag = ContextualHybridRAG()
 print(rag.query("Father receives terminal diagnosis"))

--- a/run_api.bat
+++ b/run_api.bat
@@ -2,10 +2,7 @@
 REM Activate the virtual environment
 call .venv\Scripts\activate
 
-REM Set PYTHONPATH to current directory
-set PYTHONPATH=%cd%
-
 REM Run Uvicorn with your FastAPI app
-python -m uvicorn src.api.app:app --reload
+python -m uvicorn api.app:app --reload
 
 pause

--- a/run_api.py
+++ b/run_api.py
@@ -5,10 +5,6 @@ import subprocess
 # Get absolute path to this script's directory (the project root)
 project_root = os.path.dirname(os.path.abspath(__file__))
 
-# Set PYTHONPATH to include the src directory
-src_path = os.path.join(project_root, "src")
-os.environ["PYTHONPATH"] = src_path + os.pathsep + os.environ.get("PYTHONPATH", "")
-
 # Activate virtual environment if not already active
 venv_python = os.path.join(project_root, ".venv", "Scripts", "python.exe")
 if os.path.exists(venv_python) and sys.executable.lower() != venv_python.lower():
@@ -19,7 +15,7 @@ if os.path.exists(venv_python) and sys.executable.lower() != venv_python.lower()
 # Launch Uvicorn using the correct module path
 try:
     subprocess.run([
-        sys.executable, "-m", "uvicorn", "src.api.app:app", "--reload"
+        sys.executable, "-m", "uvicorn", "api.app:app", "--reload"
     ])
 except Exception as e:
     print("Failed to launch Uvicorn:", e)


### PR DESCRIPTION
## Summary
- simplify API startup script
- switch example and scripts to use `rag_core` package
- update Dockerfile for new package path
- ensure `setup.py` exposes packages via `package_dir`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d38002d08321a045c4533a32b2a5