### PR TITLE
Add OS detection for run_api

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ This project combines hybrid retrieval, contextual chunk enhancement, and multi-
 - Sentiment-aware reranking
 - Modular architecture for scalability
 - Evaluation metrics for emotional impact and coherence
+
+## Running the API
+
+Use the ``run_api.py`` helper script to start the development server. The script
+detects your operating system and chooses the correct Python executable from the
+``.venv`` directory. On Windows it uses ``.venv\Scripts\python.exe`` while on
+Unix systems it uses ``.venv/bin/python``. Simply run:
+
+```bash
+python run_api.py
+```
+
+This will activate the virtual environment if necessary and launch Uvicorn with
+automatic reload enabled.

--- a/run_api.py
+++ b/run_api.py
@@ -10,7 +10,10 @@ src_path = os.path.join(project_root, "src")
 os.environ["PYTHONPATH"] = src_path + os.pathsep + os.environ.get("PYTHONPATH", "")
 
 # Activate virtual environment if not already active
-venv_python = os.path.join(project_root, ".venv", "Scripts", "python.exe")
+if os.name == "nt" or sys.platform == "win32":
+    venv_python = os.path.join(project_root, ".venv", "Scripts", "python.exe")
+else:
+    venv_python = os.path.join(project_root, ".venv", "bin", "python")
 if os.path.exists(venv_python) and sys.executable.lower() != venv_python.lower():
     # Relaunch this script using the venv's python
     subprocess.run([venv_python, __file__] + sys.argv[1:])


### PR DESCRIPTION
## Summary
- reload the helper script with Windows or Unix python path
- document run_api usage in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d39aa4d48321ba9ec83f3fdb370f