### PR TITLE
Add ContextualHybridRAG placeholder

### DIFF
--- a/src/rag_core/__init__.py
+++ b/src/rag_core/__init__.py
@@ -1,0 +1,5 @@
+"""Core modules for Contextual Hybrid RAG."""
+
+from .contextual_hybrid_rag import ContextualHybridRAG
+
+__all__ = ["ContextualHybridRAG"]

--- a/src/rag_core/contextual_hybrid_rag.py
+++ b/src/rag_core/contextual_hybrid_rag.py
@@ -1,0 +1,10 @@
+class ContextualHybridRAG:
+    """Placeholder implementation for Contextual Hybrid RAG."""
+
+    def __init__(self):
+        """Initialize components for retrieval and generation."""
+        pass
+
+    def query(self, text, top_k: int = 5):
+        """Return a placeholder response for the provided query text."""
+        return f"Placeholder response for '{text}' (top_k={top_k})"


### PR DESCRIPTION
## Summary
- introduce `ContextualHybridRAG` class with placeholder implementation
- expose the class in `rag_core.__init__`

## Testing
- `pytest -q`
- `PYTHONPATH=. python examples/example_query.py`
- `PYTHONPATH=src python src/api/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847d4f9405883219acf6860b7d0e012